### PR TITLE
Add minimal python3 support to the library.

### DIFF
--- a/lookup/simple-lookup-service-client-python/clients/sls_dig
+++ b/lookup/simple-lookup-service-client-python/clients/sls_dig
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 
 """
 sls_dig - client to fetch host information from sLS
@@ -60,160 +61,160 @@ def main():
     )
     (options, args) = parser.parse_args()
     if (len(args)!= 1):
-        print "Please specify hostname"
+        print("Please specify hostname")
         sys.exit(1)
 
     hostname=args[0]
     if(options.output_type=="json"):
-        print sls_client.find_host_info.get_host_info_json(hostname)
+        print(sls_client.find_host_info.get_host_info_json(hostname))
+
     elif(options.output_type=="console"):
         result = sls_client.find_host_info.get_host_info(hostname)
         for host in result:
             interfaces=host[HOST_INTERFACE]
             core=1
             count=1
-            print "\n***** HOST HARDWARE *****",
-            print "\nMemory:",
+            print("\n***** HOST HARDWARE *****", end='')
+            print("\nMemory:", end='')
             for memory in host[HOST_HW_MEMORY]:
-                print memory,
+                print(memory, end='')
             if(host[HOST_HW_PROCESSORCORE]):
                 core = int(host[HOST_HW_PROCESSORCORE][0])
             if(host[HOST_HW_PROCESSORCOUNT]):
                 count = int(host[HOST_HW_PROCESSORCOUNT][0])
 
-            print "\nNumber of processors: ",
-            print str(count),
+            print("\nNumber of processors: {}".format(count))
 
             for i in range(0,count):
-                print "\nProcessor #"+str(i)+": ",
+                print("\nProcessor #"+str(i)+": ", end='')
                 cpp=core
                 if (count>1):
                     cpp = int(core/count)
-                print str(cpp)+" cores",
-                print "\nProcessor #"+str(i)+" Speed: ",
+                print(str(cpp)+" cores", end='')
+                print("\nProcessor #"+str(i)+" Speed: ", end='')
                 for speed in host[HOST_HW_PROCESSORSPEED]:
-                    print speed,
+                    print(speed, end='')
 
-            print "\n\n***** HOST OS *****",
-            print "\nOS: ",
+            print("\n\n***** HOST OS *****", end='')
+            print("\nOS: ", end='')
             for osname in host[HOST_OS_NAME]:
-                print osname,
+                print(osname, end='')
 
-            print "\nOS Version: ",
+            print("\nOS Version: ", end='')
             for osversion in host[HOST_OS_VERSION]:
-                print osversion,
+                print(osversion, end='')
 
-            print "\nOS Kernel: ",
+            print("\nOS Kernel: ", end='')
             for oskernel in host[HOST_OS_KERNEL]:
-                print oskernel
+                print(oskernel)
 
-            print "\n***** HOST NETWORKING *****\n",
+            print("\n***** HOST NETWORKING *****\n", end='')
             if (interfaces):
                 i=0
                 for interface in interfaces:
-                    print "\n*** INTERFACE "+str(i)+" ***" ,
+                    print("\n*** INTERFACE "+str(i)+" ***" , end='')
                     i+=1
-                    print "\n"+ INTERFACE_NAME+":",
+                    print("\n"+ INTERFACE_NAME+":", end='')
                     for ifname in interface[INTERFACE_NAME]:
-                        print ifname,
+                        print(ifname, end='')
 
-                    print "\n"+ INTERFACE_ADDRESS+":",
+                    print("\n"+ INTERFACE_ADDRESS+":", end='')
                     for ip in interface[INTERFACE_ADDRESS]:
-                        print ip,
+                        print(ip, end='')
 
-                    print "\n"+ INTERFACE_MAC+":",
+                    print("\n"+ INTERFACE_MAC+":", end='')
                     for mac in interface[INTERFACE_MAC]:
-                        print mac,
+                        print(mac, end='')
 
-                    print "\n"+ INTERFACE_CAPACITY+":",
+                    print("\n"+ INTERFACE_CAPACITY+":", end='')
                     for cap in interface[INTERFACE_CAPACITY]:
                         int_cap = int(cap)
                         c = _format_metrics(int_cap)
-                        print c+"bps",
+                        print(c+"bps", end='')
 
-                    print "\n"+ INTERFACE_MTU+":",
+                    print("\n"+ INTERFACE_MTU+":", end='')
                     for mtu in interface[INTERFACE_MTU]:
-                        print mtu
+                        print(mtu)
 
-            print "\n***** HOST TCP PARAMETERS *****",
-            print "\nCongestion Algorithm: ",
+            print("\n***** HOST TCP PARAMETERS *****", end='')
+            print("\nCongestion Algorithm: ", end='')
             for alg in host[HOST_NET_TCP_CONGESTIONALGORITHM]:
-                print alg,
-            print "\nRECV Autotunemaxbuffer",
+                print(alg, end='')
+            print("\nRECV Autotunemaxbuffer", end='')
             for buf in host[HOST_NET_TCP_AUTOTUNEMAXBUFFER_RECV]:
-                print buf,
-                print "\nRECV Maxbuffer: ",
+                print(buf, end='')
+                print("\nRECV Maxbuffer: ", end='')
             for buf in host[HOST_NET_TCP_MAXBUFFER_RECV]:
-                print buf,
-            print "\nSEND Autotunemaxbuffer: ",
+                print(buf, end='')
+            print("\nSEND Autotunemaxbuffer: ", end='')
             for buf in host[HOST_NET_TCP_AUTOTUNEMAXBUFFER_SEND]:
-                print buf,
-            print "\nSEND Maxbuffer: ",
+                print(buf, end='')
+            print("\nSEND Maxbuffer: ", end='')
             for buf in host[HOST_NET_TCP_MAXBUFFER_SEND]:
-                print buf
+                print(buf)
 
 
-            print "\n***** HOST LOCATION *****",
+            print("\n***** HOST LOCATION *****", end='')
 
             if( LOCATION_SITE in host and host[LOCATION_SITE]):
-                print "\nSite Name: ",
+                print("\nSite Name: ", end='')
                 for site in host[LOCATION_SITE]:
-                    print site,
+                    print(site, end='')
 
             if(LOCATION_CITY in host and host[LOCATION_CITY]):
-                print "\nCity: ",
+                print("\nCity: ", end='')
                 for city in host[LOCATION_CITY]:
-                    print city,
+                    print(city, end='')
 
             if(LOCATION_STATE in host and host[LOCATION_STATE]):
-                print "\nState: ",
+                print("\nState: ", end='')
                 for state in host[LOCATION_STATE]:
-                    print state,
+                    print(state, end='')
 
             if(LOCATION_COUNTRY in host and host[LOCATION_COUNTRY]):
-                print "\nCountry: ",
+                print("\nCountry: ", end='')
                 for country in host[LOCATION_COUNTRY]:
-                    print country,
+                    print(country, end='')
 
             if(LOCATION_LATITUDE in host and host[LOCATION_LATITUDE]):
-                print "\nLatitude: ",
+                print("\nLatitude: ", end='')
                 for lat in host[LOCATION_LATITUDE]:
                     latitude = float(lat)
-                    print ('%.2f' %latitude),
+                    print('%.2f' % latitude, end='')
 
             if(LOCATION_LONGITUDE in host and host[LOCATION_LONGITUDE]):
-                print "\nLongitude: ",
+                print("\nLongitude: ", end='')
                 for lo in host[LOCATION_LONGITUDE]:
                     longitude = float(lo)
                     print ('%.2f' %longitude)
 
-            print "\n***** HOST ADMIN *****",
+            print("\n***** HOST ADMIN *****", end='')
             admins=host[HOST_ADMINISTRATORS]
             for admin in admins:
-                print "\nAdmin Name: ",
+                print("\nAdmin Name: ", end='')
                 for name in admin[PERSON_NAME]:
-                    print name,
+                    print(name, end='')
 
-                print "\nAdmin Email: ",
+                print("\nAdmin Email: ", end='')
                 for email in admin[PERSON_EMAILS]:
-                    print email,
+                    print(email, end='')
 
-                print "\nCity :",
+                print("\nCity :", end='')
                 for city in admin[LOCATION_CITY]:
-                    print city,
+                    print(city, end='')
 
-                print "\n State: ",
+                print("\n State: ", end='')
                 for state in admin[LOCATION_STATE]:
-                    print state,
+                    print(state, end='')
 
-                print "\nCountry: ",
+                print("\nCountry: ", end='')
                 for country in admin[LOCATION_COUNTRY]:
-                    print country
+                    print(country)
 
 
 
     else:
-        print sls_client.find_host_info.get_host_info(hostname)
+        print(sls_client.find_host_info.get_host_info(hostname))
 
 
 def _format_metrics(capacity):

--- a/lookup/simple-lookup-service-client-python/clients/sls_report
+++ b/lookup/simple-lookup-service-client-python/clients/sls_report
@@ -9,8 +9,9 @@ import logging
 import pprint
 import socket
 import time
-import urlparse
 import warnings
+
+from six.moves.urllib.parse import urlparse
 
 from collections import OrderedDict
 from multiprocessing.dummy import Process, Value
@@ -271,7 +272,7 @@ class SlsHostList(SlsReportBase):
                 host=look, sec=round(time.time() - t_start, 2)))
 
             # count how many records we got for this host for report.
-            upar = urlparse.urlparse(look)
+            upar = urlparse(look)
             self._ls_count[upar.netloc] = count_per_lookup_host
 
             if self._options.single:
@@ -536,7 +537,7 @@ class SlsStatCapsule(SlsReportBase):
         self._counter('os', os_info)
 
         if architecture:
-            arch = architecture
+            arch = architecture[0]
         else:
             arch = kernel[0].split('.')[-1]
             arch = arch.split('-')[-1]
@@ -740,7 +741,7 @@ class SlsReportFormatter(object):  # pylint: disable=too-few-public-methods
         # default name/count/percent columns
         self._columns = """{{section}} ({{count}}):
                                                      count    percent
-{% for key, val in _dict.iteritems() %}  {{ key.ljust(52) }}{{ val[0].rjust(4) }}{{ val[1].rjust(9) }} %
+{% for key, val in _dict.items() %}  {{ key.ljust(52) }}{{ val[0].rjust(4) }}{{ val[1].rjust(9) }} %
 {% endfor %}"""
 
         self._column_template = jinja2.Template(self._columns)
@@ -779,7 +780,7 @@ class SlsReportFormatter(object):  # pylint: disable=too-few-public-methods
                 else:
                     break
             fmt += self._column_template.render(
-                section=k.replace('_', ' ').title(), _dict=trimmed_val, count=strcount).encode('utf-8')
+                section=k.replace('_', ' ').title(), _dict=trimmed_val, count=strcount)
             fmt += '\n'
 
         return fmt
@@ -827,7 +828,7 @@ def main():
     try:
         lookup_hosts = SlsHostList(options, _logger)
     except SlsReportException as ex:
-        print str(ex)
+        print(str(ex))
         return -1
 
     lookup_hosts.generate_host_list()
@@ -839,7 +840,7 @@ def main():
     _logger('main.end', 'completed in {sec} seconds'.format(sec=round(time.time() - t_start, 2)))
 
     formatter = SlsReportFormatter(report.get_report, report.host_count, report.duplicates, options.ntop)
-    print formatter
+    print(formatter)
 
 if __name__ == '__main__':
     main()

--- a/lookup/simple-lookup-service-client-python/examples/queryExample.py
+++ b/lookup/simple-lookup-service-client-python/examples/queryExample.py
@@ -1,6 +1,8 @@
+from __future__ import print_function
+
 from sls_client.records import *
 from sls_client.query import *
-from sls_client.find_ps_ma import *
+from sls_client.find_ma import *
 
 ##query all  services
 #queryString = 'type=services'
@@ -15,7 +17,7 @@ queryString = 'type=host&group-domains=anl.gov'
 response = query(queryString)
 
 for record in response:
-	print record[u'host-name']
+	print(record[u'host-name'])
 
 
 #query for MA containing host data

--- a/lookup/simple-lookup-service-client-python/requirements.txt
+++ b/lookup/simple-lookup-service-client-python/requirements.txt
@@ -4,3 +4,4 @@ isodate==0.5.1
 futures==2.2.0
 requests>=2.20.0
 voluptuous==0.8.7
+six

--- a/lookup/simple-lookup-service-client-python/sls_client/query.py
+++ b/lookup/simple-lookup-service-client-python/sls_client/query.py
@@ -1,6 +1,6 @@
 from operator import itemgetter
 import urllib
-from urlparse import parse_qs
+from six.moves.urllib.parse import parse_qs
 
 import requests
 

--- a/lookup/simple-lookup-service-client-python/sls_client/records.py
+++ b/lookup/simple-lookup-service-client-python/sls_client/records.py
@@ -4,8 +4,8 @@ import json
 from voluptuous import Schema
 from voluptuous import Extra, Required
 
-from constants import *
-from validators import *
+from sls_client.constants import *
+from sls_client.validators import *
 
 class Record(object):
     """Base class for record objects"""

--- a/lookup/simple-lookup-service-client-python/sls_client/validators.py
+++ b/lookup/simple-lookup-service-client-python/sls_client/validators.py
@@ -8,7 +8,7 @@ from isodate import datetime_isoformat, duration_isoformat
 from voluptuous import All, Any, Length, Range
 from voluptuous import Invalid, MultipleInvalid
 
-from constants import *
+from sls_client.constants import *
 
 LS_MAC_ADDRESS_FORMAT = re.compile(r"^([0-9A-F]{2}[-]){5}([0-9A-F]{2})$|^([0-9A-F]{2}[:]){5}([0-9A-F]{2})$", re.IGNORECASE)
 LS_COUNTRY_FORMAT = re.compile(r"^[A-Z]{2}$", re.IGNORECASE)


### PR DESCRIPTION
I needed to utilize the `sls_client` python module from a Python3 project.

This PR uses the `six` helper library to keep python2 compatibility while adding python3 support.  It converts over a few - but not all - CLI utilities to be dual py2 / py3.